### PR TITLE
fix: resolve all MoonBit compiler warnings

### DIFF
--- a/src/builders.mbt
+++ b/src/builders.mbt
@@ -1,24 +1,24 @@
 ///| Create an empty tree
-pub fn empty[N]() -> Tree[N] {
+pub fn[N] empty() -> Tree[N] {
   Empty
 }
 
 ///| Create a tree with a single element
-pub fn singleton[N](x : N) -> Tree[N] {
+pub fn[N] singleton(x : N) -> Tree[N] {
   make_node(x, x, Empty, Empty)
 }
 
 ///| Create a tree with a single interval
-pub fn interval[N](min : N, max : N) -> Tree[N] {
+pub fn[N] interval(min : N, max : N) -> Tree[N] {
   make_node(min, max, Empty, Empty)
 }
 
 ///| Converts an array of elements into a tree
-pub fn of[N : BoundedEnum](array : Array[N]) -> Tree[N] {
+pub fn[N : BoundedEnum] of(array : Array[N]) -> Tree[N] {
   array.fold(init=Empty, fn { tree, x => union(tree, singleton(x)) })
 }
 
 ///| Converts an array view into a tree
-pub fn of_view[N : BoundedEnum](view : ArrayView[N]) -> Tree[N] {
+pub fn[N : BoundedEnum] of_view(view : ArrayView[N]) -> Tree[N] {
   view.fold(init=Empty, fn { tree, x => union(tree, singleton(x)) })
 }

--- a/src/builders.mbt
+++ b/src/builders.mbt
@@ -15,10 +15,10 @@ pub fn[N] interval(min : N, max : N) -> Tree[N] {
 
 ///| Converts an array of elements into a tree
 pub fn[N : BoundedEnum] of(array : Array[N]) -> Tree[N] {
-  array.fold(init=Empty, fn { tree, x => union(tree, singleton(x)) })
+  array.fold(init=Empty, fn(tree, x) { tree.union(singleton(x)) })
 }
 
 ///| Converts an array view into a tree
 pub fn[N : BoundedEnum] of_view(view : ArrayView[N]) -> Tree[N] {
-  view.fold(init=Empty, fn { tree, x => union(tree, singleton(x)) })
+  view.fold(init=Empty, fn(tree, x) { tree.union(singleton(x)) })
 }

--- a/src/diet.mbti
+++ b/src/diet.mbti
@@ -1,76 +1,47 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "CAIMEOX/diet"
 
 // Values
-fn add[N : BoundedEnum](Tree[N], N) -> Tree[N]
+fn[N : BoundedEnum] difference(Tree[N], Tree[N]) -> Tree[N]
 
-fn complement[N : BoundedEnum](Tree[N]) -> Tree[N]
+fn[N] empty() -> Tree[N]
 
-fn contains[N : BoundedEnum](Tree[N], N) -> Bool
+fn[N] interval(N, N) -> Tree[N]
 
-fn difference[N : BoundedEnum](Tree[N], Tree[N]) -> Tree[N]
+fn[N : BoundedEnum] is_subset(Tree[N], Tree[N]) -> Bool
 
-fn empty[N]() -> Tree[N]
+fn[N : BoundedEnum] of(Array[N]) -> Tree[N]
 
-fn fold_ranges[N : BoundedEnum, A](Tree[N], init~ : A, (A, N, N) -> A) -> A
+fn[N : BoundedEnum] of_view(ArrayView[N]) -> Tree[N]
 
-fn intersection[N : BoundedEnum](Tree[N], Tree[N]) -> Tree[N]
+fn[N] singleton(N) -> Tree[N]
 
-fn interval[N](N, N) -> Tree[N]
-
-fn is_empty[N](Tree[N]) -> Bool
-
-fn is_subset[N : BoundedEnum](Tree[N], Tree[N]) -> Bool
-
-fn iter[N : BoundedEnum](Tree[N]) -> Iter[N]
-
-fn iter_intervals[N](Tree[N]) -> Iter[(N, N)]
-
-fn of[N : BoundedEnum](Array[N]) -> Tree[N]
-
-fn of_view[N : BoundedEnum](ArrayView[N]) -> Tree[N]
-
-fn remove[N : BoundedEnum](Tree[N], N) -> Tree[N]
-
-fn singleton[N](N) -> Tree[N]
-
-fn slice[N : BoundedEnum](Tree[N], min? : N, max? : N) -> Tree[N]
-
-fn slice_after[N : BoundedEnum](Tree[N], N) -> Tree[N]
-
-fn slice_before[N : BoundedEnum](Tree[N], N) -> Tree[N]
-
-fn slice_from[N : BoundedEnum](Tree[N], N) -> Tree[N]
-
-fn slice_until[N : BoundedEnum](Tree[N], N) -> Tree[N]
-
-fn union[N : BoundedEnum](Tree[N], Tree[N]) -> Tree[N]
+// Errors
 
 // Types and methods
 type Tree[T]
-impl Tree {
-  add[N : BoundedEnum](Self[N], N) -> Self[N]
-  complement[N : BoundedEnum](Self[N]) -> Self[N]
-  contains[N : BoundedEnum](Self[N], N) -> Bool
-  fold_ranges[N : BoundedEnum, A](Self[N], init~ : A, (A, N, N) -> A) -> A
-  intersection[N : BoundedEnum](Self[N], Self[N]) -> Self[N]
-  is_empty[N](Self[N]) -> Bool
-  iter[N : BoundedEnum](Self[N]) -> Iter[N]
-  iter_intervals[N](Self[N]) -> Iter[(N, N)]
-  remove[N : BoundedEnum](Self[N], N) -> Self[N]
-  slice[N : BoundedEnum](Self[N], min? : N, max? : N) -> Self[N]
-  slice_after[N : BoundedEnum](Self[N], N) -> Self[N]
-  slice_before[N : BoundedEnum](Self[N], N) -> Self[N]
-  slice_from[N : BoundedEnum](Self[N], N) -> Self[N]
-  slice_until[N : BoundedEnum](Self[N], N) -> Self[N]
-  union[N : BoundedEnum](Self[N], Self[N]) -> Self[N]
-}
+fn[N : BoundedEnum] Tree::add(Self[N], N) -> Self[N]
+fn[N : BoundedEnum] Tree::complement(Self[N]) -> Self[N]
+fn[N : BoundedEnum] Tree::contains(Self[N], N) -> Bool
+fn[N : BoundedEnum, A] Tree::fold_ranges(Self[N], init~ : A, (A, N, N) -> A) -> A
+fn[N : BoundedEnum] Tree::intersection(Self[N], Self[N]) -> Self[N]
+fn[N] Tree::is_empty(Self[N]) -> Bool
+fn[N : BoundedEnum] Tree::iter(Self[N]) -> Iter[N]
+fn[N] Tree::iter_intervals(Self[N]) -> Iter[(N, N)]
+fn[N : BoundedEnum] Tree::remove(Self[N], N) -> Self[N]
+fn[N : BoundedEnum] Tree::slice(Self[N], min? : N, max? : N) -> Self[N]
+fn[N : BoundedEnum] Tree::slice_after(Self[N], N) -> Self[N]
+fn[N : BoundedEnum] Tree::slice_before(Self[N], N) -> Self[N]
+fn[N : BoundedEnum] Tree::slice_from(Self[N], N) -> Self[N]
+fn[N : BoundedEnum] Tree::slice_until(Self[N], N) -> Self[N]
+fn[N : BoundedEnum] Tree::union(Self[N], Self[N]) -> Self[N]
 impl[N : Compare] Compare for Tree[N]
 impl[N] Default for Tree[N]
 impl[N : Eq] Eq for Tree[N]
 impl[N : Hash] Hash for Tree[N]
 
 // Type aliases
-pub typealias T[T] = Tree[T]
+pub typealias Tree as T
 
 // Traits
 pub(open) trait BoundedEnum : Compare {

--- a/src/diet.mbti
+++ b/src/diet.mbti
@@ -23,7 +23,7 @@ type Tree[T]
 fn[N : BoundedEnum] Tree::add(Self[N], N) -> Self[N]
 fn[N : BoundedEnum] Tree::complement(Self[N]) -> Self[N]
 fn[N : BoundedEnum] Tree::contains(Self[N], N) -> Bool
-fn[N : BoundedEnum, A] Tree::fold_ranges(Self[N], init~ : A, (A, N, N) -> A) -> A
+fn[N, A] Tree::fold_ranges(Self[N], init~ : A, (A, N, N) -> A) -> A
 fn[N : BoundedEnum] Tree::intersection(Self[N], Self[N]) -> Self[N]
 fn[N] Tree::is_empty(Self[N]) -> Bool
 fn[N : BoundedEnum] Tree::iter(Self[N]) -> Iter[N]

--- a/src/diet_test.mbt
+++ b/src/diet_test.mbt
@@ -1,19 +1,19 @@
 ///|
 test "empty" {
   let empty : @diet.T[Char] = @diet.empty()
-  inspect!(empty.iter().to_array(), content="[]")
+  inspect(empty.iter().to_array(), content="[]")
 }
 
 ///|
 test "singleton" {
   let singleton : @diet.T[Char] = @diet.singleton('a')
-  inspect!(singleton.iter().to_array(), content="['a']")
+  inspect(singleton.iter().to_array(), content="['a']")
 }
 
 ///|
 test "interval" {
   let interval : @diet.T[Char] = @diet.interval('0', '9')
-  inspect!(
+  inspect(
     interval.iter().to_array(),
     content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']",
   )
@@ -23,7 +23,7 @@ test "interval" {
 test "slice with min" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let slice : @diet.T[Char] = @diet.slice(a, min='3')
-  inspect!(
+  inspect(
     slice.iter().to_array(),
     content="['3', '4', '5', '6', '7', '8', '9']",
   )
@@ -33,14 +33,14 @@ test "slice with min" {
 test "slice with max" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let slice : @diet.T[Char] = @diet.slice(a, max='3')
-  inspect!(slice.iter().to_array(), content="['0', '1', '2', '3']")
+  inspect(slice.iter().to_array(), content="['0', '1', '2', '3']")
 }
 
 ///|
 test "slice with min and max" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let slice : @diet.T[Char] = @diet.slice(a, min='3', max='6')
-  inspect!(slice.iter().to_array(), content="['3', '4', '5', '6']")
+  inspect(slice.iter().to_array(), content="['3', '4', '5', '6']")
 }
 
 ///|
@@ -48,7 +48,7 @@ test "union adjacent" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('5', '9')
   let union : @diet.T[Char] = @diet.union(a, b)
-  inspect!(
+  inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']",
   )
@@ -59,7 +59,7 @@ test "union overlapping" {
   let a : @diet.T[Char] = @diet.interval('0', '5')
   let b : @diet.T[Char] = @diet.interval('4', '9')
   let union : @diet.T[Char] = @diet.union(a, b)
-  inspect!(
+  inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']",
   )
@@ -70,7 +70,7 @@ test "union disjoint" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('6', '9')
   let union : @diet.T[Char] = @diet.union(a, b)
-  inspect!(
+  inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '6', '7', '8', '9']",
   )
@@ -81,7 +81,7 @@ test "union containing" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let b : @diet.T[Char] = @diet.interval('3', '6')
   let union : @diet.T[Char] = @diet.union(a, b)
-  inspect!(
+  inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']",
   )
@@ -92,7 +92,7 @@ test "intersection adjacent" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('4', '9')
   let intersection : @diet.T[Char] = @diet.intersection(a, b)
-  inspect!(intersection.iter().to_array(), content="['4']")
+  inspect(intersection.iter().to_array(), content="['4']")
 }
 
 ///|
@@ -100,7 +100,7 @@ test "intersection overlapping" {
   let a : @diet.T[Char] = @diet.interval('0', '5')
   let b : @diet.T[Char] = @diet.interval('4', '9')
   let intersection : @diet.T[Char] = @diet.intersection(a, b)
-  inspect!(intersection.iter().to_array(), content="['4', '5']")
+  inspect(intersection.iter().to_array(), content="['4', '5']")
 }
 
 ///|
@@ -108,7 +108,7 @@ test "intersection disjoint" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('6', '9')
   let intersection : @diet.T[Char] = @diet.intersection(a, b)
-  inspect!(intersection.iter().to_array(), content="[]")
+  inspect(intersection.iter().to_array(), content="[]")
 }
 
 ///|
@@ -116,14 +116,14 @@ test "intersection containing" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let b : @diet.T[Char] = @diet.interval('3', '6')
   let intersection : @diet.T[Char] = @diet.intersection(a, b)
-  inspect!(intersection.iter().to_array(), content="['3', '4', '5', '6']")
+  inspect(intersection.iter().to_array(), content="['3', '4', '5', '6']")
 }
 
 ///|
 test "complement empty" {
   let empty : @diet.T[Char] = @diet.empty()
   let complement : @diet.T[Char] = @diet.complement(empty)
-  inspect!(
+  inspect(
     complement.iter_intervals().to_array(),
     content="[('\\x00', '\u{10ffff}')]",
   )
@@ -133,7 +133,7 @@ test "complement empty" {
 test "complement single interval" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let complement : @diet.T[Char] = @diet.complement(a)
-  inspect!(
+  inspect(
     complement.iter_intervals().to_array(),
     content="[('\\x00', '/'), (':', '\u{10ffff}')]",
   )
@@ -146,7 +146,7 @@ test "complement multiple intervals" {
     @diet.interval('6', '9'),
   )
   let complement : @diet.T[Char] = @diet.complement(a)
-  inspect!(
+  inspect(
     complement.iter_intervals().to_array(),
     content="[('\\x00', '/'), ('5', '5'), (':', '\u{10ffff}')]",
   )
@@ -157,7 +157,7 @@ test "difference" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let b : @diet.T[Char] = @diet.interval('3', '6')
   let difference : @diet.T[Char] = @diet.difference(a, b)
-  inspect!(
+  inspect(
     difference.iter().to_array(),
     content="['0', '1', '2', '7', '8', '9']",
   )
@@ -171,44 +171,44 @@ test "add" {
   let x = @diet.interval(4, 8)
   let y = @diet.union(c, x)
   let z = y.add(5)
-  inspect!(c.iter().to_array(), content="[1, 10]")
-  inspect!(y.iter().to_array(), content="[1, 4, 5, 6, 7, 8, 10]")
-  inspect!(z.iter().to_array(), content="[1, 4, 5, 6, 7, 8, 10]")
+  inspect(c.iter().to_array(), content="[1, 10]")
+  inspect(y.iter().to_array(), content="[1, 4, 5, 6, 7, 8, 10]")
+  inspect(z.iter().to_array(), content="[1, 4, 5, 6, 7, 8, 10]")
 }
 
 ///|
 test "until empty" {
   let empty : @diet.T[Char] = @diet.empty()
   let result : @diet.T[Char] = @diet.slice_until(empty, '5')
-  inspect!(result.iter().to_array(), content="[]")
+  inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "until - value not in tree" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_until(a, '0') // '0' comes before 'a'
-  inspect!(result.iter().to_array(), content="[]")
+  inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "until - value in interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_until(a, 'c')
-  inspect!(result.iter().to_array(), content="['a', 'b', 'c']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'c']")
 }
 
 ///|
 test "until - value equal to max" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_until(a, 'e')
-  inspect!(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "until - value after interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_until(a, 'z')
-  inspect!(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
@@ -220,9 +220,9 @@ test "until - multiple intervals" {
   let result1 : @diet.T[Char] = @diet.slice_until(a, 'b')
   let result2 : @diet.T[Char] = @diet.slice_until(a, 'd')
   let result3 : @diet.T[Char] = @diet.slice_until(a, 'h')
-  inspect!(result1.iter().to_array(), content="['a', 'b']")
-  inspect!(result2.iter().to_array(), content="['a', 'b', 'c']")
-  inspect!(result3.iter().to_array(), content="['a', 'b', 'c', 'g', 'h']")
+  inspect(result1.iter().to_array(), content="['a', 'b']")
+  inspect(result2.iter().to_array(), content="['a', 'b', 'c']")
+  inspect(result3.iter().to_array(), content="['a', 'b', 'c', 'g', 'h']")
 }
 
 ///|
@@ -232,42 +232,42 @@ test "until - with integers" {
     @diet.interval(10, 15),
   )
   let result : @diet.T[Int] = @diet.slice_until(a, 12)
-  inspect!(result.iter().to_array(), content="[1, 2, 3, 4, 5, 10, 11, 12]")
+  inspect(result.iter().to_array(), content="[1, 2, 3, 4, 5, 10, 11, 12]")
 }
 
 ///|
 test "from empty" {
   let empty : @diet.T[Char] = @diet.empty()
   let result : @diet.T[Char] = @diet.slice_from(empty, '5')
-  inspect!(result.iter().to_array(), content="[]")
+  inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "from - value not in tree" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_from(a, 'z') // 'z' comes after 'e'
-  inspect!(result.iter().to_array(), content="[]")
+  inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "from - value in interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_from(a, 'c')
-  inspect!(result.iter().to_array(), content="['c', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['c', 'd', 'e']")
 }
 
 ///|
 test "from - value equal to min" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_from(a, 'a')
-  inspect!(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "from - value before interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.slice_from(a, '0')
-  inspect!(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
@@ -279,9 +279,9 @@ test "from - multiple intervals" {
   let result1 : @diet.T[Char] = @diet.slice_from(a, 'b')
   let result2 : @diet.T[Char] = @diet.slice_from(a, 'd')
   let result3 : @diet.T[Char] = @diet.slice_from(a, 'h')
-  inspect!(result1.iter().to_array(), content="['b', 'c', 'g', 'h', 'i']")
-  inspect!(result2.iter().to_array(), content="['g', 'h', 'i']")
-  inspect!(result3.iter().to_array(), content="['h', 'i']")
+  inspect(result1.iter().to_array(), content="['b', 'c', 'g', 'h', 'i']")
+  inspect(result2.iter().to_array(), content="['g', 'h', 'i']")
+  inspect(result3.iter().to_array(), content="['h', 'i']")
 }
 
 ///|
@@ -291,10 +291,7 @@ test "from - with integers" {
     @diet.interval(10, 15),
   )
   let result : @diet.T[Int] = @diet.slice_from(a, 3)
-  inspect!(
-    result.iter().to_array(),
-    content="[3, 4, 5, 10, 11, 12, 13, 14, 15]",
-  )
+  inspect(result.iter().to_array(), content="[3, 4, 5, 10, 11, 12, 13, 14, 15]")
 }
 
 ///|
@@ -304,7 +301,7 @@ test "from and until combined" {
   let until_t : @diet.T[Char] = @diet.slice_until(from_m, 't')
 
   // Should contain characters from 'm' to 't'
-  inspect!(
+  inspect(
     until_t.iter().to_array(),
     content="['m', 'n', 'o', 'p', 'q', 'r', 's', 't']",
   )
@@ -314,46 +311,46 @@ test "from and until combined" {
 test "remove from empty" {
   let empty : @diet.T[Char] = @diet.empty()
   let result : @diet.T[Char] = @diet.remove(empty, '5')
-  inspect!(result.iter().to_array(), content="[]")
+  inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "remove - value not in tree" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.remove(a, 'z') // 'z' not in tree
-  inspect!(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "remove - singleton" {
   let a : @diet.T[Char] = @diet.singleton('a')
   let result : @diet.T[Char] = @diet.remove(a, 'a')
-  inspect!(result.iter().to_array(), content="[]")
+  inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "remove - from start of interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.remove(a, 'a')
-  inspect!(result.iter().to_array(), content="['b', 'c', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['b', 'c', 'd', 'e']")
 }
 
 ///|
 test "remove - from end of interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.remove(a, 'e')
-  inspect!(result.iter().to_array(), content="['a', 'b', 'c', 'd']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd']")
 }
 
 ///|
 test "remove - from middle of interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result : @diet.T[Char] = @diet.remove(a, 'c')
-  inspect!(
+  inspect(
     result.iter_intervals().to_array(),
     content="[('a', 'b'), ('d', 'e')]",
   )
-  inspect!(result.iter().to_array(), content="['a', 'b', 'd', 'e']")
+  inspect(result.iter().to_array(), content="['a', 'b', 'd', 'e']")
 }
 
 ///|
@@ -361,11 +358,11 @@ test "remove - multiple elements" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result1 : @diet.T[Char] = @diet.remove(a, 'b')
   let result2 : @diet.T[Char] = @diet.remove(result1, 'd')
-  inspect!(
+  inspect(
     result2.iter_intervals().to_array(),
     content="[('a', 'a'), ('c', 'c'), ('e', 'e')]",
   )
-  inspect!(result2.iter().to_array(), content="['a', 'c', 'e']")
+  inspect(result2.iter().to_array(), content="['a', 'c', 'e']")
 }
 
 ///|
@@ -376,8 +373,8 @@ test "remove - from multiple intervals" {
   )
   let result1 : @diet.T[Char] = @diet.remove(a, 'a')
   let result2 : @diet.T[Char] = @diet.remove(a, 'h')
-  inspect!(result1.iter().to_array(), content="['b', 'c', 'g', 'h', 'i']")
-  inspect!(result2.iter().to_array(), content="['a', 'b', 'c', 'g', 'i']")
+  inspect(result1.iter().to_array(), content="['b', 'c', 'g', 'h', 'i']")
+  inspect(result2.iter().to_array(), content="['a', 'b', 'c', 'g', 'i']")
 }
 
 ///|
@@ -386,9 +383,9 @@ test "remove - with integers" {
   let result1 : @diet.T[Int] = @diet.remove(a, 1)
   let result2 : @diet.T[Int] = @diet.remove(a, 3)
   let result3 : @diet.T[Int] = @diet.remove(a, 5)
-  inspect!(result1.iter().to_array(), content="[2, 3, 4, 5]")
-  inspect!(result2.iter_intervals().to_array(), content="[(1, 2), (4, 5)]")
-  inspect!(result3.iter().to_array(), content="[1, 2, 3, 4]")
+  inspect(result1.iter().to_array(), content="[2, 3, 4, 5]")
+  inspect(result2.iter_intervals().to_array(), content="[(1, 2), (4, 5)]")
+  inspect(result3.iter().to_array(), content="[1, 2, 3, 4]")
 }
 
 ///|
@@ -396,8 +393,8 @@ test "remove - add and remove same element" {
   let a : @diet.T[Int] = @diet.empty()
   let with_added : @diet.T[Int] = @diet.add(a, 10)
   let with_removed : @diet.T[Int] = @diet.remove(with_added, 10)
-  inspect!(with_added.iter().to_array(), content="[10]")
-  inspect!(with_removed.iter().to_array(), content="[]")
+  inspect(with_added.iter().to_array(), content="[10]")
+  inspect(with_removed.iter().to_array(), content="[]")
 }
 
 ///|
@@ -407,9 +404,9 @@ test "subset - empty sets" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let result2 = @diet.is_subset(empty, a)
   let result3 = @diet.is_subset(a, empty)
-  inspect!(result1, content="true") // Empty is subset of empty
-  inspect!(result2, content="true") // Empty is subset of any set
-  inspect!(result3, content="false") // Non-empty is not subset of empty
+  inspect(result1, content="true") // Empty is subset of empty
+  inspect(result2, content="true") // Empty is subset of any set
+  inspect(result3, content="false") // Non-empty is not subset of empty
 }
 
 ///|
@@ -417,7 +414,7 @@ test "subset - equal sets" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
   let b : @diet.T[Char] = @diet.interval('a', 'e')
   let result = @diet.is_subset(a, b)
-  inspect!(result, content="true") // A set is a subset of itself
+  inspect(result, content="true") // A set is a subset of itself
 }
 
 ///|
@@ -425,7 +422,7 @@ test "subset - proper subset" {
   let a : @diet.T[Char] = @diet.interval('b', 'd')
   let b : @diet.T[Char] = @diet.interval('a', 'e')
   let result = @diet.is_subset(a, b)
-  inspect!(result, content="true") // Smaller interval is subset of larger
+  inspect(result, content="true") // Smaller interval is subset of larger
 }
 
 ///|
@@ -433,7 +430,7 @@ test "subset - not a subset" {
   let a : @diet.T[Char] = @diet.interval('a', 'f')
   let b : @diet.T[Char] = @diet.interval('b', 'e')
   let result = @diet.is_subset(a, b)
-  inspect!(result, content="false") // a-f is not a subset of b-e
+  inspect(result, content="false") // a-f is not a subset of b-e
 }
 
 ///|
@@ -441,7 +438,7 @@ test "subset - overlapping" {
   let a : @diet.T[Char] = @diet.interval('a', 'c')
   let b : @diet.T[Char] = @diet.interval('b', 'e')
   let result = @diet.is_subset(a, b)
-  inspect!(result, content="false") // a-c is not a subset of b-e
+  inspect(result, content="false") // a-c is not a subset of b-e
 }
 
 ///|
@@ -449,7 +446,7 @@ test "subset - disjoint" {
   let a : @diet.T[Char] = @diet.interval('a', 'c')
   let b : @diet.T[Char] = @diet.interval('d', 'f')
   let result = @diet.is_subset(a, b)
-  inspect!(result, content="false") // Disjoint sets
+  inspect(result, content="false") // Disjoint sets
 }
 
 ///|
@@ -465,8 +462,8 @@ test "subset - multiple intervals" {
   )
   let result1 = @diet.is_subset(a, b)
   let result2 = @diet.is_subset(c, b)
-  inspect!(result1, content="true") // b-c is subset of a-d,g-i
-  inspect!(result2, content="true") // b-c,h-i is subset of a-d,g-i
+  inspect(result1, content="true") // b-c is subset of a-d,g-i
+  inspect(result2, content="true") // b-c,h-i is subset of a-d,g-i
 }
 
 ///|
@@ -480,7 +477,7 @@ test "subset - complex relationship" {
     @diet.interval('f', 'h'),
   )
   let result = @diet.is_subset(a, b)
-  inspect!(result, content="true") // b-c,f-g is subset of a-d,f-h
+  inspect(result, content="true") // b-c,f-g is subset of a-d,f-h
 }
 
 ///|
@@ -494,7 +491,7 @@ test "subset - with integers" {
     @diet.interval(8, 12),
   )
   let result = @diet.is_subset(a, b)
-  inspect!(result, content="true") // 2-4,10-11 is subset of 1-5,8-12
+  inspect(result, content="true") // 2-4,10-11 is subset of 1-5,8-12
 }
 
 ///|
@@ -508,7 +505,7 @@ test "fold - empty tree" {
       let (min, max) = mm
       acc + max - min + 1
     })
-  inspect!(count, content="0")
+  inspect(count, content="0")
 }
 
 ///|
@@ -519,7 +516,7 @@ test "fold - singleton tree" {
   let count = @diet.fold_ranges(singleton, init=0, fn(acc, min, max) {
     acc + (max - min + 1)
   })
-  inspect!(count, content="1")
+  inspect(count, content="1")
 }
 
 ///|
@@ -539,6 +536,6 @@ test "fold - single interval" {
       acc + ", \{min}-\{max}"
     }
   })
-  inspect!(count, content="4")
-  inspect!(intervals, content="1-4")
+  inspect(count, content="4")
+  inspect(intervals, content="1-4")
 }

--- a/src/diet_test.mbt
+++ b/src/diet_test.mbt
@@ -22,7 +22,7 @@ test "interval" {
 ///|
 test "slice with min" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
-  let slice : @diet.T[Char] = @diet.slice(a, min='3')
+  let slice : @diet.T[Char] = a.slice(min='3')
   inspect(
     slice.iter().to_array(),
     content="['3', '4', '5', '6', '7', '8', '9']",
@@ -32,14 +32,14 @@ test "slice with min" {
 ///|
 test "slice with max" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
-  let slice : @diet.T[Char] = @diet.slice(a, max='3')
+  let slice : @diet.T[Char] = a.slice(max='3')
   inspect(slice.iter().to_array(), content="['0', '1', '2', '3']")
 }
 
 ///|
 test "slice with min and max" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
-  let slice : @diet.T[Char] = @diet.slice(a, min='3', max='6')
+  let slice : @diet.T[Char] = a.slice(min='3', max='6')
   inspect(slice.iter().to_array(), content="['3', '4', '5', '6']")
 }
 
@@ -47,7 +47,7 @@ test "slice with min and max" {
 test "union adjacent" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('5', '9')
-  let union : @diet.T[Char] = @diet.union(a, b)
+  let union : @diet.T[Char] = a.union(b)
   inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']",
@@ -58,7 +58,7 @@ test "union adjacent" {
 test "union overlapping" {
   let a : @diet.T[Char] = @diet.interval('0', '5')
   let b : @diet.T[Char] = @diet.interval('4', '9')
-  let union : @diet.T[Char] = @diet.union(a, b)
+  let union : @diet.T[Char] = a.union(b)
   inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']",
@@ -69,7 +69,7 @@ test "union overlapping" {
 test "union disjoint" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('6', '9')
-  let union : @diet.T[Char] = @diet.union(a, b)
+  let union : @diet.T[Char] = a.union(b)
   inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '6', '7', '8', '9']",
@@ -80,7 +80,7 @@ test "union disjoint" {
 test "union containing" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let b : @diet.T[Char] = @diet.interval('3', '6')
-  let union : @diet.T[Char] = @diet.union(a, b)
+  let union : @diet.T[Char] = a.union(b)
   inspect(
     union.iter().to_array(),
     content="['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']",
@@ -91,7 +91,7 @@ test "union containing" {
 test "intersection adjacent" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('4', '9')
-  let intersection : @diet.T[Char] = @diet.intersection(a, b)
+  let intersection : @diet.T[Char] = a.intersection(b)
   inspect(intersection.iter().to_array(), content="['4']")
 }
 
@@ -99,7 +99,7 @@ test "intersection adjacent" {
 test "intersection overlapping" {
   let a : @diet.T[Char] = @diet.interval('0', '5')
   let b : @diet.T[Char] = @diet.interval('4', '9')
-  let intersection : @diet.T[Char] = @diet.intersection(a, b)
+  let intersection : @diet.T[Char] = a.intersection(b)
   inspect(intersection.iter().to_array(), content="['4', '5']")
 }
 
@@ -107,7 +107,7 @@ test "intersection overlapping" {
 test "intersection disjoint" {
   let a : @diet.T[Char] = @diet.interval('0', '4')
   let b : @diet.T[Char] = @diet.interval('6', '9')
-  let intersection : @diet.T[Char] = @diet.intersection(a, b)
+  let intersection : @diet.T[Char] = a.intersection(b)
   inspect(intersection.iter().to_array(), content="[]")
 }
 
@@ -115,14 +115,14 @@ test "intersection disjoint" {
 test "intersection containing" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
   let b : @diet.T[Char] = @diet.interval('3', '6')
-  let intersection : @diet.T[Char] = @diet.intersection(a, b)
+  let intersection : @diet.T[Char] = a.intersection(b)
   inspect(intersection.iter().to_array(), content="['3', '4', '5', '6']")
 }
 
 ///|
 test "complement empty" {
   let empty : @diet.T[Char] = @diet.empty()
-  let complement : @diet.T[Char] = @diet.complement(empty)
+  let complement : @diet.T[Char] = empty.complement()
   inspect(
     complement.iter_intervals().to_array(),
     content="[('\\x00', '\u{10ffff}')]",
@@ -132,7 +132,7 @@ test "complement empty" {
 ///|
 test "complement single interval" {
   let a : @diet.T[Char] = @diet.interval('0', '9')
-  let complement : @diet.T[Char] = @diet.complement(a)
+  let complement : @diet.T[Char] = a.complement()
   inspect(
     complement.iter_intervals().to_array(),
     content="[('\\x00', '/'), (':', '\u{10ffff}')]",
@@ -141,11 +141,10 @@ test "complement single interval" {
 
 ///|
 test "complement multiple intervals" {
-  let a : @diet.T[Char] = @diet.union(
-    @diet.interval('0', '4'),
+  let a : @diet.T[Char] = @diet.interval('0', '4').union(
     @diet.interval('6', '9'),
   )
-  let complement : @diet.T[Char] = @diet.complement(a)
+  let complement : @diet.T[Char] = a.complement()
   inspect(
     complement.iter_intervals().to_array(),
     content="[('\\x00', '/'), ('5', '5'), (':', '\u{10ffff}')]",
@@ -169,7 +168,7 @@ test "add" {
   let b = a.add(1)
   let c = b.add(10)
   let x = @diet.interval(4, 8)
-  let y = @diet.union(c, x)
+  let y = c.union(x)
   let z = y.add(5)
   inspect(c.iter().to_array(), content="[1, 10]")
   inspect(y.iter().to_array(), content="[1, 4, 5, 6, 7, 8, 10]")
@@ -179,47 +178,46 @@ test "add" {
 ///|
 test "until empty" {
   let empty : @diet.T[Char] = @diet.empty()
-  let result : @diet.T[Char] = @diet.slice_until(empty, '5')
+  let result : @diet.T[Char] = empty.slice_until('5')
   inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "until - value not in tree" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_until(a, '0') // '0' comes before 'a'
+  let result : @diet.T[Char] = a.slice_until('0') // '0' comes before 'a'
   inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "until - value in interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_until(a, 'c')
+  let result : @diet.T[Char] = a.slice_until('c')
   inspect(result.iter().to_array(), content="['a', 'b', 'c']")
 }
 
 ///|
 test "until - value equal to max" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_until(a, 'e')
+  let result : @diet.T[Char] = a.slice_until('e')
   inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "until - value after interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_until(a, 'z')
+  let result : @diet.T[Char] = a.slice_until('z')
   inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "until - multiple intervals" {
-  let a : @diet.T[Char] = @diet.union(
-    @diet.interval('a', 'c'),
+  let a : @diet.T[Char] = @diet.interval('a', 'c').union(
     @diet.interval('g', 'i'),
   )
-  let result1 : @diet.T[Char] = @diet.slice_until(a, 'b')
-  let result2 : @diet.T[Char] = @diet.slice_until(a, 'd')
-  let result3 : @diet.T[Char] = @diet.slice_until(a, 'h')
+  let result1 : @diet.T[Char] = a.slice_until('b')
+  let result2 : @diet.T[Char] = a.slice_until('d')
+  let result3 : @diet.T[Char] = a.slice_until('h')
   inspect(result1.iter().to_array(), content="['a', 'b']")
   inspect(result2.iter().to_array(), content="['a', 'b', 'c']")
   inspect(result3.iter().to_array(), content="['a', 'b', 'c', 'g', 'h']")
@@ -227,58 +225,54 @@ test "until - multiple intervals" {
 
 ///|
 test "until - with integers" {
-  let a : @diet.T[Int] = @diet.union(
-    @diet.interval(1, 5),
-    @diet.interval(10, 15),
-  )
-  let result : @diet.T[Int] = @diet.slice_until(a, 12)
+  let a : @diet.T[Int] = @diet.interval(1, 5).union(@diet.interval(10, 15))
+  let result : @diet.T[Int] = a.slice_until(12)
   inspect(result.iter().to_array(), content="[1, 2, 3, 4, 5, 10, 11, 12]")
 }
 
 ///|
 test "from empty" {
   let empty : @diet.T[Char] = @diet.empty()
-  let result : @diet.T[Char] = @diet.slice_from(empty, '5')
+  let result : @diet.T[Char] = empty.slice_from('5')
   inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "from - value not in tree" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_from(a, 'z') // 'z' comes after 'e'
+  let result : @diet.T[Char] = a.slice_from('z') // 'z' comes after 'e'
   inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "from - value in interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_from(a, 'c')
+  let result : @diet.T[Char] = a.slice_from('c')
   inspect(result.iter().to_array(), content="['c', 'd', 'e']")
 }
 
 ///|
 test "from - value equal to min" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_from(a, 'a')
+  let result : @diet.T[Char] = a.slice_from('a')
   inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "from - value before interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.slice_from(a, '0')
+  let result : @diet.T[Char] = a.slice_from('0')
   inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "from - multiple intervals" {
-  let a : @diet.T[Char] = @diet.union(
-    @diet.interval('a', 'c'),
+  let a : @diet.T[Char] = @diet.interval('a', 'c').union(
     @diet.interval('g', 'i'),
   )
-  let result1 : @diet.T[Char] = @diet.slice_from(a, 'b')
-  let result2 : @diet.T[Char] = @diet.slice_from(a, 'd')
-  let result3 : @diet.T[Char] = @diet.slice_from(a, 'h')
+  let result1 : @diet.T[Char] = a.slice_from('b')
+  let result2 : @diet.T[Char] = a.slice_from('d')
+  let result3 : @diet.T[Char] = a.slice_from('h')
   inspect(result1.iter().to_array(), content="['b', 'c', 'g', 'h', 'i']")
   inspect(result2.iter().to_array(), content="['g', 'h', 'i']")
   inspect(result3.iter().to_array(), content="['h', 'i']")
@@ -286,19 +280,16 @@ test "from - multiple intervals" {
 
 ///|
 test "from - with integers" {
-  let a : @diet.T[Int] = @diet.union(
-    @diet.interval(1, 5),
-    @diet.interval(10, 15),
-  )
-  let result : @diet.T[Int] = @diet.slice_from(a, 3)
+  let a : @diet.T[Int] = @diet.interval(1, 5).union(@diet.interval(10, 15))
+  let result : @diet.T[Int] = a.slice_from(3)
   inspect(result.iter().to_array(), content="[3, 4, 5, 10, 11, 12, 13, 14, 15]")
 }
 
 ///|
 test "from and until combined" {
   let a : @diet.T[Char] = @diet.interval('a', 'z')
-  let from_m : @diet.T[Char] = @diet.slice_from(a, 'm')
-  let until_t : @diet.T[Char] = @diet.slice_until(from_m, 't')
+  let from_m : @diet.T[Char] = a.slice_from('m')
+  let until_t : @diet.T[Char] = from_m.slice_until('t')
 
   // Should contain characters from 'm' to 't'
   inspect(
@@ -310,42 +301,42 @@ test "from and until combined" {
 ///|
 test "remove from empty" {
   let empty : @diet.T[Char] = @diet.empty()
-  let result : @diet.T[Char] = @diet.remove(empty, '5')
+  let result : @diet.T[Char] = empty.remove('5')
   inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "remove - value not in tree" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.remove(a, 'z') // 'z' not in tree
+  let result : @diet.T[Char] = a.remove('z') // 'z' not in tree
   inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd', 'e']")
 }
 
 ///|
 test "remove - singleton" {
   let a : @diet.T[Char] = @diet.singleton('a')
-  let result : @diet.T[Char] = @diet.remove(a, 'a')
+  let result : @diet.T[Char] = a.remove('a')
   inspect(result.iter().to_array(), content="[]")
 }
 
 ///|
 test "remove - from start of interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.remove(a, 'a')
+  let result : @diet.T[Char] = a.remove('a')
   inspect(result.iter().to_array(), content="['b', 'c', 'd', 'e']")
 }
 
 ///|
 test "remove - from end of interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.remove(a, 'e')
+  let result : @diet.T[Char] = a.remove('e')
   inspect(result.iter().to_array(), content="['a', 'b', 'c', 'd']")
 }
 
 ///|
 test "remove - from middle of interval" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result : @diet.T[Char] = @diet.remove(a, 'c')
+  let result : @diet.T[Char] = a.remove('c')
   inspect(
     result.iter_intervals().to_array(),
     content="[('a', 'b'), ('d', 'e')]",
@@ -356,8 +347,8 @@ test "remove - from middle of interval" {
 ///|
 test "remove - multiple elements" {
   let a : @diet.T[Char] = @diet.interval('a', 'e')
-  let result1 : @diet.T[Char] = @diet.remove(a, 'b')
-  let result2 : @diet.T[Char] = @diet.remove(result1, 'd')
+  let result1 : @diet.T[Char] = a.remove('b')
+  let result2 : @diet.T[Char] = result1.remove('d')
   inspect(
     result2.iter_intervals().to_array(),
     content="[('a', 'a'), ('c', 'c'), ('e', 'e')]",
@@ -367,12 +358,11 @@ test "remove - multiple elements" {
 
 ///|
 test "remove - from multiple intervals" {
-  let a : @diet.T[Char] = @diet.union(
-    @diet.interval('a', 'c'),
+  let a : @diet.T[Char] = @diet.interval('a', 'c').union(
     @diet.interval('g', 'i'),
   )
-  let result1 : @diet.T[Char] = @diet.remove(a, 'a')
-  let result2 : @diet.T[Char] = @diet.remove(a, 'h')
+  let result1 : @diet.T[Char] = a.remove('a')
+  let result2 : @diet.T[Char] = a.remove('h')
   inspect(result1.iter().to_array(), content="['b', 'c', 'g', 'h', 'i']")
   inspect(result2.iter().to_array(), content="['a', 'b', 'c', 'g', 'i']")
 }
@@ -380,9 +370,9 @@ test "remove - from multiple intervals" {
 ///|
 test "remove - with integers" {
   let a : @diet.T[Int] = @diet.interval(1, 5)
-  let result1 : @diet.T[Int] = @diet.remove(a, 1)
-  let result2 : @diet.T[Int] = @diet.remove(a, 3)
-  let result3 : @diet.T[Int] = @diet.remove(a, 5)
+  let result1 : @diet.T[Int] = a.remove(1)
+  let result2 : @diet.T[Int] = a.remove(3)
+  let result3 : @diet.T[Int] = a.remove(5)
   inspect(result1.iter().to_array(), content="[2, 3, 4, 5]")
   inspect(result2.iter_intervals().to_array(), content="[(1, 2), (4, 5)]")
   inspect(result3.iter().to_array(), content="[1, 2, 3, 4]")
@@ -391,8 +381,8 @@ test "remove - with integers" {
 ///|
 test "remove - add and remove same element" {
   let a : @diet.T[Int] = @diet.empty()
-  let with_added : @diet.T[Int] = @diet.add(a, 10)
-  let with_removed : @diet.T[Int] = @diet.remove(with_added, 10)
+  let with_added : @diet.T[Int] = a.add(10)
+  let with_removed : @diet.T[Int] = with_added.remove(10)
   inspect(with_added.iter().to_array(), content="[10]")
   inspect(with_removed.iter().to_array(), content="[]")
 }
@@ -452,12 +442,10 @@ test "subset - disjoint" {
 ///|
 test "subset - multiple intervals" {
   let a : @diet.T[Char] = @diet.interval('b', 'c')
-  let b : @diet.T[Char] = @diet.union(
-    @diet.interval('a', 'd'),
+  let b : @diet.T[Char] = @diet.interval('a', 'd').union(
     @diet.interval('g', 'i'),
   )
-  let c : @diet.T[Char] = @diet.union(
-    @diet.interval('b', 'c'),
+  let c : @diet.T[Char] = @diet.interval('b', 'c').union(
     @diet.interval('h', 'i'),
   )
   let result1 = @diet.is_subset(a, b)
@@ -468,12 +456,10 @@ test "subset - multiple intervals" {
 
 ///|
 test "subset - complex relationship" {
-  let a : @diet.T[Char] = @diet.union(
-    @diet.interval('b', 'c'),
+  let a : @diet.T[Char] = @diet.interval('b', 'c').union(
     @diet.interval('f', 'g'),
   )
-  let b : @diet.T[Char] = @diet.union(
-    @diet.interval('a', 'd'),
+  let b : @diet.T[Char] = @diet.interval('a', 'd').union(
     @diet.interval('f', 'h'),
   )
   let result = @diet.is_subset(a, b)
@@ -482,14 +468,8 @@ test "subset - complex relationship" {
 
 ///|
 test "subset - with integers" {
-  let a : @diet.T[Int] = @diet.union(
-    @diet.interval(2, 4),
-    @diet.interval(10, 11),
-  )
-  let b : @diet.T[Int] = @diet.union(
-    @diet.interval(1, 5),
-    @diet.interval(8, 12),
-  )
+  let a : @diet.T[Int] = @diet.interval(2, 4).union(@diet.interval(10, 11))
+  let b : @diet.T[Int] = @diet.interval(1, 5).union(@diet.interval(8, 12))
   let result = @diet.is_subset(a, b)
   inspect(result, content="true") // 2-4,10-11 is subset of 1-5,8-12
 }
@@ -513,7 +493,7 @@ test "fold - singleton tree" {
   let singleton : @diet.T[Int] = @diet.singleton('x')
 
   // Sum of interval lengths (should be 1)
-  let count = @diet.fold_ranges(singleton, init=0, fn(acc, min, max) {
+  let count = singleton.fold_ranges(init=0, fn(acc, min, max) {
     acc + (max - min + 1)
   })
   inspect(count, content="1")
@@ -524,12 +504,12 @@ test "fold - single interval" {
   let interval : @diet.T[Int] = @diet.interval(1, 4)
 
   // Sum of interval lengths
-  let count = @diet.fold_ranges(interval, init=0, fn(acc, min, max) {
+  let count = interval.fold_ranges(init=0, fn(acc, min, max) {
     acc + (max - min) + 1
   })
 
   // Collecting intervals as strings
-  let intervals = @diet.fold_ranges(interval, init="", fn(acc, min, max) {
+  let intervals = interval.fold_ranges(init="", fn(acc, min, max) {
     if acc == "" {
       "\{min}-\{max}"
     } else {

--- a/src/impls.mbt
+++ b/src/impls.mbt
@@ -1,21 +1,21 @@
 ///|
 pub impl BoundedEnum for Char with pred(self) {
-  Char::from_int(self.to_int() - 1)
+  (self.to_int() - 1).unsafe_to_char()
 }
 
 ///|
 pub impl BoundedEnum for Char with succ(self) {
-  Char::from_int(self.to_int() + 1)
+  (self.to_int() + 1).unsafe_to_char()
 }
 
 ///|
 pub impl BoundedEnum for Char with lower_bound() {
-  Char::from_int(0)
+  Int::unsafe_to_char(0)
 }
 
 ///|
 pub impl BoundedEnum for Char with upper_bound() {
-  Char::from_int(0x10ffff)
+  Int::unsafe_to_char(0x10ffff)
 }
 
 ///|

--- a/src/inorder_iterator.mbt
+++ b/src/inorder_iterator.mbt
@@ -1,28 +1,28 @@
 ///|
-priv type InorderIterator[N] Array[Tree[N]]
+priv struct InorderIterator[N](Array[Tree[N]])
 
 ///|
-fn InorderIterator::new[N](root : T[N]) -> InorderIterator[N] {
+fn[N] InorderIterator::new(root : T[N]) -> InorderIterator[N] {
   InorderIterator([])..move_left(root)
 }
 
 ///|
-fn InorderIterator::move_left[N](
+fn[N] InorderIterator::move_left(
   self : InorderIterator[N],
-  node : T[N]
+  node : T[N],
 ) -> Unit {
   loop node {
     Empty => ()
     Node(left~, ..) as curr => {
-      self._.push(curr)
+      self.inner().push(curr)
       continue left
     }
   }
 }
 
 ///|
-fn InorderIterator::next[N](self : InorderIterator[N]) -> (N, N)? {
-  guard self._.pop() is Some(curr) else { return None }
+fn[N] InorderIterator::next(self : InorderIterator[N]) -> (N, N)? {
+  guard self.inner().pop() is Some(curr) else { return None }
   guard curr is Node(min~, max~, right~, ..)
   self.move_left(right)
   Some((min, max))

--- a/src/inorder_iterator.mbt
+++ b/src/inorder_iterator.mbt
@@ -3,7 +3,9 @@ priv struct InorderIterator[N](Array[Tree[N]])
 
 ///|
 fn[N] InorderIterator::new(root : T[N]) -> InorderIterator[N] {
-  InorderIterator([])..move_left(root)
+  let iter = InorderIterator([])
+  iter..move_left(root)
+  iter
 }
 
 ///|

--- a/src/iter.mbt
+++ b/src/iter.mbt
@@ -4,11 +4,11 @@ pub fn[N] iter_intervals(self : Tree[N]) -> Iter[(N, N)] {
     match self {
       Empty => IterContinue
       Node(..) as t => {
-        guard iter_intervals(t.left).run(yield_) is IterContinue else {
+        guard t.left.iter_intervals().run(yield_) is IterContinue else {
           return IterEnd
         }
         guard yield_((t.min, t.max)) is IterContinue else { return IterEnd }
-        guard iter_intervals(t.right).run(yield_) is IterContinue else {
+        guard t.right.iter_intervals().run(yield_) is IterContinue else {
           return IterEnd
         }
         IterContinue
@@ -21,13 +21,13 @@ pub fn[N] iter_intervals(self : Tree[N]) -> Iter[(N, N)] {
 pub fn[N : BoundedEnum] iter(self : Tree[N]) -> Iter[N] {
   self
   .iter_intervals()
-  .flat_map(fn {
-    (min, max) =>
-      Iter::new(fn(yield_) {
-        for x = min; x <= max; x = N::succ(x) {
-          guard yield_(x) is IterContinue else { return IterEnd }
-        }
-        IterContinue
-      })
+  .flat_map(fn(interval) {
+    let (min, max) = interval
+    Iter::new(fn(yield_) {
+      for x = min; x <= max; x = N::succ(x) {
+        guard yield_(x) is IterContinue else { return IterEnd }
+      }
+      IterContinue
+    })
   })
 }

--- a/src/iter.mbt
+++ b/src/iter.mbt
@@ -1,5 +1,5 @@
 ///| Create a new iterator over intervals
-pub fn iter_intervals[N](self : Tree[N]) -> Iter[(N, N)] {
+pub fn[N] iter_intervals(self : Tree[N]) -> Iter[(N, N)] {
   Iter::new(fn(yield_) {
     match self {
       Empty => IterContinue
@@ -18,7 +18,7 @@ pub fn iter_intervals[N](self : Tree[N]) -> Iter[(N, N)] {
 }
 
 ///| Create a new iterator over the elements represent by the tree
-pub fn iter[N : BoundedEnum](self : Tree[N]) -> Iter[N] {
+pub fn[N : BoundedEnum] iter(self : Tree[N]) -> Iter[N] {
   self
   .iter_intervals()
   .flat_map(fn {
@@ -26,7 +26,6 @@ pub fn iter[N : BoundedEnum](self : Tree[N]) -> Iter[N] {
       Iter::new(fn(yield_) {
         for x = min; x <= max; x = N::succ(x) {
           guard yield_(x) is IterContinue else { return IterEnd }
-
         }
         IterContinue
       })

--- a/src/ops.mbt
+++ b/src/ops.mbt
@@ -1,5 +1,5 @@
 ///| Checks if a tree is empty.
-pub fn is_empty[N](self : Tree[N]) -> Bool {
+pub fn[N] is_empty(self : Tree[N]) -> Bool {
   match self {
     Empty => true
     Node(..) => false
@@ -7,7 +7,7 @@ pub fn is_empty[N](self : Tree[N]) -> Bool {
 }
 
 ///| Determines if a discrete interval encoding tree contains a specific value.
-pub fn contains[N : BoundedEnum](self : Tree[N], x : N) -> Bool {
+pub fn[N : BoundedEnum] contains(self : Tree[N], x : N) -> Bool {
   match self {
     Empty => false
     Node(..) as t =>
@@ -22,7 +22,7 @@ pub fn contains[N : BoundedEnum](self : Tree[N], x : N) -> Bool {
 }
 
 ///| Computes the union of two discrete interval encoding trees.
-pub fn union[N : BoundedEnum](self : Tree[N], t2 : Tree[N]) -> Tree[N] {
+pub fn[N : BoundedEnum] union(self : Tree[N], t2 : Tree[N]) -> Tree[N] {
   match (self, t2) {
     (Empty, Empty) => Empty
     (Empty, Node(..) as t) | (Node(..) as t, Empty) => t
@@ -34,7 +34,7 @@ pub fn union[N : BoundedEnum](self : Tree[N], t2 : Tree[N]) -> Tree[N] {
 }
 
 ///| Helper function for computing the union of two non-empty trees.
-fn union_aux[N : BoundedEnum](t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
+fn[N : BoundedEnum] union_aux(t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
   guard t1 is (Node(..) as t1)
   guard t2 is (Node(..) as t2)
   let l1 = t1.left
@@ -77,7 +77,7 @@ fn union_aux[N : BoundedEnum](t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
 }
 
 ///| Computes the intersection of two discrete interval encoding trees.
-pub fn intersection[N : BoundedEnum](self : Tree[N], t2 : Tree[N]) -> Tree[N] {
+pub fn[N : BoundedEnum] intersection(self : Tree[N], t2 : Tree[N]) -> Tree[N] {
   match (self, t2) {
     (Empty, _) | (_, Empty) => Empty
     (Node(..) as t1, Node(..) as t2) => {
@@ -88,7 +88,7 @@ pub fn intersection[N : BoundedEnum](self : Tree[N], t2 : Tree[N]) -> Tree[N] {
 }
 
 ///| Helper function for computing the intersection of two non-empty trees.
-fn intersection_aux[N : BoundedEnum](t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
+fn[N : BoundedEnum] intersection_aux(t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
   guard t1 is (Node(..) as t1)
   guard t2 is (Node(..) as t2)
   let l1 = t1.left
@@ -102,12 +102,12 @@ fn intersection_aux[N : BoundedEnum](t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
 }
 
 ///| Computes the complement of a discrete interval encoding tree.
-pub fn complement[N : BoundedEnum](self : Tree[N]) -> Tree[N] {
+pub fn[N : BoundedEnum] complement(self : Tree[N]) -> Tree[N] {
   complement_aux(N::lower_bound(), N::upper_bound(), self)
 }
 
 ///| Helper function for computing the complement of a tree within a range.
-fn complement_aux[N : BoundedEnum](min : N, max : N, t : Tree[N]) -> Tree[N] {
+fn[N : BoundedEnum] complement_aux(min : N, max : N, t : Tree[N]) -> Tree[N] {
   match t {
     Empty => interval(min, max)
     Node(..) as t => {
@@ -127,12 +127,12 @@ fn complement_aux[N : BoundedEnum](min : N, max : N, t : Tree[N]) -> Tree[N] {
 }
 
 ///| Computes the difference between two discrete interval encoding trees.
-pub fn difference[N : BoundedEnum](t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
+pub fn[N : BoundedEnum] difference(t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
   t1.intersection(t2.complement())
 }
 
 ///| Adds a single value to a discrete interval encoding tree.
-pub fn add[N : BoundedEnum](self : Tree[N], n : N) -> Tree[N] {
+pub fn[N : BoundedEnum] add(self : Tree[N], n : N) -> Tree[N] {
   guard not(self.is_empty()) else { make_node(n, n, Empty, Empty) }
   guard self is (Node(min=v1, max=v2, left=s0, right=s1, ..) as s)
   if v1 != N::lower_bound() && n < N::pred(v1) {
@@ -161,7 +161,7 @@ pub fn add[N : BoundedEnum](self : Tree[N], n : N) -> Tree[N] {
 }
 
 ///| Removes a single value from a discrete interval encoding tree.
-pub fn remove[N : BoundedEnum](self : Tree[N], n : N) -> Tree[N] {
+pub fn[N : BoundedEnum] remove(self : Tree[N], n : N) -> Tree[N] {
   match self {
     Empty => Empty
     Node(min=v1, max=v2, left=s1, right=s2, ..) =>
@@ -186,7 +186,7 @@ pub fn remove[N : BoundedEnum](self : Tree[N], n : N) -> Tree[N] {
 }
 
 ///| Checks if one discrete interval encoding tree is a subset of another.
-pub fn is_subset[N : BoundedEnum](s1 : Tree[N], s2 : Tree[N]) -> Bool {
+pub fn[N : BoundedEnum] is_subset(s1 : Tree[N], s2 : Tree[N]) -> Bool {
   match (s1, s2) {
     (Empty, _) => true
     (_, Empty) => false
@@ -199,10 +199,10 @@ pub fn is_subset[N : BoundedEnum](s1 : Tree[N], s2 : Tree[N]) -> Bool {
 }
 
 ///| Applies a function to each interval in the tree and accumulates the results.
-pub fn fold_ranges[N : BoundedEnum, A](
+pub fn[N : BoundedEnum, A] fold_ranges(
   self : Tree[N],
   init~ : A,
-  f : (A, N, N) -> A
+  f : (A, N, N) -> A,
 ) -> A {
   self.iter_intervals().fold(init~, fn { acc, (min, max) => f(acc, min, max) })
 }

--- a/src/ops.mbt
+++ b/src/ops.mbt
@@ -44,7 +44,7 @@ fn[N : BoundedEnum] union_aux(t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
   let (min, l) = if t1.min == N::lower_bound() {
     (t1.min, Empty)
   } else {
-    let l = union(l1, l2)
+    let l = l1.union(l2)
     match l {
       Empty => (t1.min, Empty)
       Node(_) => {
@@ -60,7 +60,7 @@ fn[N : BoundedEnum] union_aux(t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
   let (max, r) = if t1.max == N::upper_bound() {
     (t1.max, Empty)
   } else {
-    let r = union(r1, r2)
+    let r = r1.union(r2)
     match r {
       Empty => (t1.max, Empty)
       Node(_) => {
@@ -95,8 +95,8 @@ fn[N : BoundedEnum] intersection_aux(t1 : Tree[N], t2 : Tree[N]) -> Tree[N] {
   let r1 = t1.right
   let l2 = t2.slice_before(t1.min)
   let r2 = t2.slice_after(t1.max)
-  let l = intersection(l1, l2)
-  let r = intersection(r1, r2)
+  let l = l1.intersection(l2)
+  let r = r1.intersection(r2)
   let m = t2.slice(min=t1.min, max=t1.max)
   concat(concat(l, m), r)
 }
@@ -199,10 +199,11 @@ pub fn[N : BoundedEnum] is_subset(s1 : Tree[N], s2 : Tree[N]) -> Bool {
 }
 
 ///| Applies a function to each interval in the tree and accumulates the results.
-pub fn[N : BoundedEnum, A] fold_ranges(
-  self : Tree[N],
-  init~ : A,
-  f : (A, N, N) -> A,
-) -> A {
-  self.iter_intervals().fold(init~, fn { acc, (min, max) => f(acc, min, max) })
+pub fn[N, A] fold_ranges(self : Tree[N], init~ : A, f : (A, N, N) -> A) -> A {
+  self
+  .iter_intervals()
+  .fold(init~, fn(acc, interval) {
+    let (min, max) = interval
+    f(acc, min, max)
+  })
 }

--- a/src/slice.mbt
+++ b/src/slice.mbt
@@ -4,9 +4,9 @@ pub fn[N : BoundedEnum] slice_from(self : Tree[N], x : N) -> Tree[N] {
     Empty => Empty
     Node(..) as t =>
       if x < t.min {
-        balance(t.min, t.max, slice_from(t.left, x), t.right)
+        balance(t.min, t.max, t.left.slice_from(x), t.right)
       } else if x > t.max {
-        slice_from(t.right, x)
+        t.right.slice_from(x)
       } else {
         balance(x, t.max, Empty, t.right)
       }
@@ -19,9 +19,9 @@ pub fn[N : BoundedEnum] slice_until(self : Tree[N], x : N) -> Tree[N] {
     Empty => Empty
     Node(..) as t =>
       if x > t.max {
-        balance(t.min, t.max, t.left, slice_until(t.right, x))
+        balance(t.min, t.max, t.left, t.right.slice_until(x))
       } else if x < t.min {
-        slice_until(t.left, x)
+        t.left.slice_until(x)
       } else {
         balance(t.min, x, t.left, Empty)
       }
@@ -33,7 +33,7 @@ pub fn[N : BoundedEnum] slice_before(self : Tree[N], x : N) -> Tree[N] {
   if x == N::lower_bound() {
     Empty
   } else {
-    slice_until(self, N::pred(x))
+    self.slice_until(N::pred(x))
   }
 }
 
@@ -42,7 +42,7 @@ pub fn[N : BoundedEnum] slice_after(self : Tree[N], x : N) -> Tree[N] {
   if x == N::upper_bound() {
     Empty
   } else {
-    slice_from(self, N::succ(x))
+    self.slice_from(N::succ(x))
   }
 }
 
@@ -50,8 +50,8 @@ pub fn[N : BoundedEnum] slice_after(self : Tree[N], x : N) -> Tree[N] {
 pub fn[N : BoundedEnum] slice(self : Tree[N], min? : N, max? : N) -> Tree[N] {
   match (min, max) {
     (None, None) => panic()
-    (Some(min), None) => slice_from(self, min)
-    (None, Some(max)) => slice_until(self, max)
-    (Some(min), Some(max)) => slice_until(slice_from(self, min), max)
+    (Some(min), None) => self.slice_from(min)
+    (None, Some(max)) => self.slice_until(max)
+    (Some(min), Some(max)) => self.slice_from(min).slice_until(max)
   }
 }

--- a/src/slice.mbt
+++ b/src/slice.mbt
@@ -1,5 +1,5 @@
 ///| Returns a tree containing all elements greater than or equal to x.
-pub fn slice_from[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
+pub fn[N : BoundedEnum] slice_from(self : Tree[N], x : N) -> Tree[N] {
   match self {
     Empty => Empty
     Node(..) as t =>
@@ -14,7 +14,7 @@ pub fn slice_from[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
 }
 
 ///| Returns a tree containing all elements less than or equal to x.
-pub fn slice_until[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
+pub fn[N : BoundedEnum] slice_until(self : Tree[N], x : N) -> Tree[N] {
   match self {
     Empty => Empty
     Node(..) as t =>
@@ -29,7 +29,7 @@ pub fn slice_until[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
 }
 
 ///| Returns a tree containing all elements strictly less than x.
-pub fn slice_before[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
+pub fn[N : BoundedEnum] slice_before(self : Tree[N], x : N) -> Tree[N] {
   if x == N::lower_bound() {
     Empty
   } else {
@@ -38,7 +38,7 @@ pub fn slice_before[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
 }
 
 ///| Returns a tree containing all elements strictly greater than x.
-pub fn slice_after[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
+pub fn[N : BoundedEnum] slice_after(self : Tree[N], x : N) -> Tree[N] {
   if x == N::upper_bound() {
     Empty
   } else {
@@ -47,7 +47,7 @@ pub fn slice_after[N : BoundedEnum](self : Tree[N], x : N) -> Tree[N] {
 }
 
 ///| Returns a tree containing all elements within the specified range.
-pub fn slice[N : BoundedEnum](self : Tree[N], min? : N, max? : N) -> Tree[N] {
+pub fn[N : BoundedEnum] slice(self : Tree[N], min? : N, max? : N) -> Tree[N] {
   match (min, max) {
     (None, None) => panic()
     (Some(min), None) => slice_from(self, min)

--- a/src/traits_impl.mbt
+++ b/src/traits_impl.mbt
@@ -20,7 +20,7 @@ pub impl[N : Eq] Eq for Tree[N] with op_equal(self : Tree[N], other : Tree[N]) {
 ///|
 pub impl[N : Compare] Compare for Tree[N] with compare(
   self : Tree[N],
-  other : Tree[N]
+  other : Tree[N],
 ) {
   let iter = InorderIterator::new(self)
   let iter1 = InorderIterator::new(other)

--- a/src/traits_impl.mbt
+++ b/src/traits_impl.mbt
@@ -7,13 +7,13 @@ pub impl[N] Default for Tree[N] with default() {
 pub impl[N : Eq] Eq for Tree[N] with op_equal(self : Tree[N], other : Tree[N]) {
   let iter = InorderIterator::new(self)
   let iter1 = InorderIterator::new(other)
-  loop iter.next(), iter1.next() {
-    None, None => true
-    Some(a), Some(b) => {
+  loop (iter.next(), iter1.next()) {
+    (None, None) => true
+    (Some(a), Some(b)) => {
       guard a == b else { break false }
-      continue iter.next(), iter1.next()
+      continue (iter.next(), iter1.next())
     }
-    _, _ => false
+    _ => false
   }
 }
 
@@ -24,15 +24,15 @@ pub impl[N : Compare] Compare for Tree[N] with compare(
 ) {
   let iter = InorderIterator::new(self)
   let iter1 = InorderIterator::new(other)
-  loop iter.next(), iter1.next() {
-    None, None => 0
-    Some(a), Some(b) => {
+  loop (iter.next(), iter1.next()) {
+    (None, None) => 0
+    (Some(a), Some(b)) => {
       let cmp = a.compare(b)
       guard cmp == 0 else { break cmp }
-      continue iter.next(), iter1.next()
+      continue (iter.next(), iter1.next())
     }
-    Some(_), None => 1
-    None, Some(_) => -1
+    (Some(_), None) => 1
+    (None, Some(_)) => -1
   }
 }
 

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -1,5 +1,5 @@
 ///|
-pub typealias T[T] = Tree[T]
+pub typealias Tree as T
 
 ///|
 enum Tree[T] {

--- a/src/util.mbt
+++ b/src/util.mbt
@@ -1,5 +1,5 @@
 ///|
-fn split_leftmost[N](t : Tree[N]) -> ((N, N), Tree[N]) {
+fn[N] split_leftmost(t : Tree[N]) -> ((N, N), Tree[N]) {
   match t {
     Empty => panic()
     Node(left=Empty, right~, min~, max~, ..) => ((min, max), right)
@@ -11,7 +11,7 @@ fn split_leftmost[N](t : Tree[N]) -> ((N, N), Tree[N]) {
 }
 
 ///|
-fn split_rightmost[N](t : Tree[N]) -> ((N, N), Tree[N]) {
+fn[N] split_rightmost(t : Tree[N]) -> ((N, N), Tree[N]) {
   match t {
     Empty => panic()
     Node(left~, right=Empty, min~, max~, ..) => ((min, max), left)

--- a/src/wbt.mbt
+++ b/src/wbt.mbt
@@ -5,7 +5,7 @@ const DELTA = 3
 const RATIO = 2
 
 ///|
-fn size[N](self : Tree[N]) -> Int {
+fn[N] size(self : Tree[N]) -> Int {
   match self {
     Empty => 0
     Node(size~, ..) => size
@@ -13,25 +13,25 @@ fn size[N](self : Tree[N]) -> Int {
 }
 
 ///|
-fn make_node[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
+fn[N] make_node(min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
   let size = size(l) + size(r) + 1
   Node(left=l, right=r, size~, min~, max~)
 }
 
 ///|
-fn single_l[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
+fn[N] single_l(min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
   guard r is (Node(..) as r)
   make_node(r.min, r.max, make_node(min, max, l, r.left), r.right)
 }
 
 ///|
-fn single_r[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
+fn[N] single_r(min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
   guard l is (Node(..) as l)
   make_node(l.min, l.max, l.left, make_node(min, max, l.right, r))
 }
 
 ///|
-fn double_l[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
+fn[N] double_l(min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
   guard r is (Node(left=Node(..) as rl, ..) as r)
   make_node(
     rl.min,
@@ -42,7 +42,7 @@ fn double_l[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
 }
 
 ///|
-fn double_r[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
+fn[N] double_r(min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
   guard l is (Node(right=Node(..) as lr, ..) as l)
   make_node(
     lr.min,
@@ -53,7 +53,7 @@ fn double_r[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
 }
 
 ///|
-fn balance[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
+fn[N] balance(min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
   let l_size = l.size()
   let r_size = r.size()
   if l_size + r_size <= 1 {
@@ -78,7 +78,7 @@ fn balance[N](min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
 }
 
 ///|
-fn concat[N](l : Tree[N], r : Tree[N]) -> Tree[N] {
+fn[N] concat(l : Tree[N], r : Tree[N]) -> Tree[N] {
   match (l, r) {
     (Empty, _) => r
     (_, Empty) => l

--- a/src/wbt.mbt
+++ b/src/wbt.mbt
@@ -14,7 +14,7 @@ fn[N] size(self : Tree[N]) -> Int {
 
 ///|
 fn[N] make_node(min : N, max : N, l : Tree[N], r : Tree[N]) -> Tree[N] {
-  let size = size(l) + size(r) + 1
+  let size = l.size() + r.size() + 1
   Node(left=l, right=r, size~, min~, max~)
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit fixes all MoonBit compiler warnings by updating deprecated syntax:

1. Changed `fn { ... }` anonymous matrix function syntax to `fn(args) { ... }`
2. Updated deprecated function call syntax `f(..)` to proper method calls `x.f(..)` or `T::f(..)`
3. Fixed deprecated loop syntax `loop a, b { ... }` to `loop (a, b) { ... }`
4. Replaced deprecated `Char::from_int()` with `Int::unsafe_to_char()`
5. Updated deprecated value chain syntax `x..f()` to `{ x..f(); x }`
6. Removed unused trait bounds
7. Fixed all function calls in test files to use proper method call syntax

All warnings have been resolved while maintaining the same functionality.

Co-authored-by: Previous commits
- style: update code format
- style: update interface files